### PR TITLE
[Feature] support create hive external table

### DIFF
--- a/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
+++ b/fe/fe-core/src/main/java/com/starrocks/connector/hive/HiveMetastoreOperations.java
@@ -181,6 +181,9 @@ public class HiveMetastoreOperations {
                 .setProperties(stmt.getProperties())
                 .setStorageFormat(HiveStorageFormat.get(properties.getOrDefault(FILE_FORMAT, "parquet")))
                 .setCreateTime(System.currentTimeMillis());
+        if (stmt.isExternal()) {
+            builder.setHiveTableType(HiveTable.HiveTableType.EXTERNAL_TABLE);
+        }
         Table table = builder.build();
         try {
             createDirectory(tablePath, hadoopConf);


### PR DESCRIPTION
transfer the external flag to HiveMetastoreOperations to support create external table on hive

## Why I'm doing:
enale starrocks to create external table on hive

## What I'm doing:


Fixes #issue

## What type of PR is this:

- [ ] BugFix
- [x] Feature
- [ ] Enhancement
- [ ] Refactor
- [ ] UT
- [ ] Doc
- [ ] Tool

Does this PR entail a change in behavior?

- [x] Yes, this PR will result in a change in behavior.
- [ ] No, this PR will not result in a change in behavior.

If yes, please specify the type of change:

- [ ] Interface/UI changes: syntax, type conversion, expression evaluation, display information
- [x] Parameter changes: default values, similar parameters but with different default values
- [ ] Policy changes: use new policy to replace old one, functionality automatically enabled
- [ ] Feature removed
- [ ] Miscellaneous: upgrade & downgrade compatibility, etc.

nowadays starrocks create hive table to managed table  no matter the SQL is CREATE TABLE or CREATE EXTERNAL TABLE
this change will recognize the external flag to the exact type of the hive table

## Checklist:

- [ ] I have added test cases for my bug fix or my new feature
- [x] This pr needs user documentation (for new or modified features or behaviors)
  - [ ] I have added documentation for my new feature or new function
- [ ] This is a backport pr

## Bugfix cherry-pick branch check:
- [ ] I have checked the version labels which the pr will be auto-backported to the target branch
  - [ ] 3.2
  - [ ] 3.1
  - [ ] 3.0
  - [ ] 2.5
